### PR TITLE
Create separate api for nearest node calculation

### DIFF
--- a/Controllers/RouteNodeController.cs
+++ b/Controllers/RouteNodeController.cs
@@ -140,9 +140,6 @@ namespace ai_indoor_nav_api.Controllers
             context.RouteNodes.Add(node);
             await context.SaveChangesAsync();
 
-            // Update closest nodes for POIs after creating the new node
-            await navigationService.UpdatePoiClosestNodesAsync(node);
-
             return CreatedAtAction(nameof(GetRouteNode), new { id = node.Id }, node.ToGeoJsonFeature());
         }
 


### PR DESCRIPTION
Separate POI nearest node calculation into a dedicated API endpoint and remove it from node creation to improve performance.

The previous implementation automatically triggered a recalculation of the nearest node for all POIs whenever a new route node was added. This led to significant performance overhead during node creation, as the operation was often unnecessary. This PR moves the heavy computation to an explicit API call, making node creation faster and allowing the recalculation to be triggered only when required.

---
Linear Issue: [SAM-23](https://linear.app/samishuraim/issue/SAM-23/calculate-nearest-node-to-each-poi-should-be-a-separate-api-call)

<a href="https://cursor.com/background-agent?bcId=bc-bc85b954-a59f-4fb7-a8b7-c66973af48c4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-bc85b954-a59f-4fb7-a8b7-c66973af48c4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

