### PR TITLE
Fix automatic object id generation and migrate

### DIFF
--- a/Controllers/BeaconTypeController.cs
+++ b/Controllers/BeaconTypeController.cs
@@ -102,10 +102,20 @@ namespace ai_indoor_nav_api.Controllers
         [HttpPost]
         public async Task<ActionResult<BeaconType>> PostBeaconType(BeaconType beaconType)
         {
-            context.BeaconTypes.Add(beaconType);
+            // Ensure ID is not set by the client - let database generate it
+            var newBeaconType = new BeaconType
+            {
+                Name = beaconType.Name,
+                Description = beaconType.Description,
+                TransmissionPower = beaconType.TransmissionPower,
+                BatteryLife = beaconType.BatteryLife,
+                RangeMeters = beaconType.RangeMeters
+            };
+
+            context.BeaconTypes.Add(newBeaconType);
             await context.SaveChangesAsync();
 
-            return CreatedAtAction("GetBeaconType", new { id = beaconType.Id }, beaconType);
+            return CreatedAtAction("GetBeaconType", new { id = newBeaconType.Id }, newBeaconType);
         }
 
         // DELETE: api/BeaconType/5

--- a/Controllers/BuildingController.cs
+++ b/Controllers/BuildingController.cs
@@ -69,14 +69,19 @@ namespace ai_indoor_nav_api.Controllers
         [HttpPost]
         public async Task<ActionResult<Building>> PostBuilding(Building building)
         {
-            // Set timestamps
-            building.CreatedAt = DateTime.UtcNow;
-            building.UpdatedAt = DateTime.UtcNow;
+            // Ensure ID is not set by the client - let database generate it
+            var newBuilding = new Building
+            {
+                Name = building.Name,
+                Description = building.Description,
+                CreatedAt = DateTime.UtcNow,
+                UpdatedAt = DateTime.UtcNow
+            };
 
-            context.Buildings.Add(building);
+            context.Buildings.Add(newBuilding);
             await context.SaveChangesAsync();
 
-            return CreatedAtAction("GetBuilding", new { id = building.Id }, building);
+            return CreatedAtAction("GetBuilding", new { id = newBuilding.Id }, newBuilding);
         }
 
         // DELETE: api/Building/5

--- a/Controllers/FloorController.cs
+++ b/Controllers/FloorController.cs
@@ -86,14 +86,20 @@ namespace ai_indoor_nav_api.Controllers
         [HttpPost]
         public async Task<ActionResult<Floor>> PostFloor(Floor floor)
         {
-            // Set timestamps
-            floor.CreatedAt = DateTime.UtcNow;
-            floor.UpdatedAt = DateTime.UtcNow;
+            // Ensure ID is not set by the client - let database generate it
+            var newFloor = new Floor
+            {
+                Name = floor.Name,
+                FloorNumber = floor.FloorNumber,
+                BuildingId = floor.BuildingId,
+                CreatedAt = DateTime.UtcNow,
+                UpdatedAt = DateTime.UtcNow
+            };
 
-            context.Floors.Add(floor);
+            context.Floors.Add(newFloor);
             await context.SaveChangesAsync();
 
-            return CreatedAtAction("GetFloor", new { id = floor.Id }, floor);
+            return CreatedAtAction("GetFloor", new { id = newFloor.Id }, newFloor);
         }
 
         // DELETE: api/Floor/5

--- a/Controllers/PoiCategoryController.cs
+++ b/Controllers/PoiCategoryController.cs
@@ -81,10 +81,18 @@ namespace ai_indoor_nav_api.Controllers
         [HttpPost]
         public async Task<ActionResult<PoiCategory>> PostPoiCategory(PoiCategory poiCategory)
         {
-            context.PoiCategories.Add(poiCategory);
+            // Ensure ID is not set by the client - let database generate it
+            var newPoiCategory = new PoiCategory
+            {
+                Name = poiCategory.Name,
+                Color = poiCategory.Color,
+                Description = poiCategory.Description
+            };
+
+            context.PoiCategories.Add(newPoiCategory);
             await context.SaveChangesAsync();
 
-            return CreatedAtAction("GetPoiCategory", new { id = poiCategory.Id }, poiCategory);
+            return CreatedAtAction("GetPoiCategory", new { id = newPoiCategory.Id }, newPoiCategory);
         }
 
         // DELETE: api/PoiCategory/5

--- a/ID_AUTO_INCREMENT_FIX.md
+++ b/ID_AUTO_INCREMENT_FIX.md
@@ -1,0 +1,106 @@
+# ID Auto-Increment Fix
+
+## Problem Fixed
+
+The application was allowing the frontend to specify ID values when creating new records, which is a security and data integrity issue. The database should automatically generate unique ID values for all new records.
+
+## Changes Made
+
+### 1. Model Changes
+- Updated all model ID properties from `{ get; set; }` to `{ get; init; }` to prevent manual assignment after object creation
+- Affected models:
+  - `Building.Id`
+  - `Floor.Id` 
+  - `Beacon.Id`
+  - `BeaconType.Id`
+  - `Poi.Id` (already had `init`)
+  - `PoiCategory.Id` (already had `init`)
+  - `RouteNode.Id`
+
+### 2. Controller Changes
+- Modified all POST endpoints to ignore incoming ID values and create new objects with only the necessary properties
+- Updated controllers:
+  - `BuildingController.PostBuilding()`
+  - `FloorController.PostFloor()`
+  - `BeaconTypeController.PostBeaconType()`
+  - `PoiCategoryController.PostPoiCategory()`
+
+### 3. RequestParser Changes
+- Updated `GeoJsonExtensions.FromFlattened()` method to skip ID properties when parsing JSON
+- Updated `GeoJsonExtensions.PopulateFromJson()` method to skip ID properties when updating objects
+- This affects controllers that use `RequestParser`:
+  - `BeaconController.PostBeacon()`
+  - `PoiController.PostPoi()`
+  - `RouteNodeController.CreateRouteNode()`
+
+### 4. Database Migration
+- Created migration `20250921175423_FixAutoIncrementSequences`
+- Includes SQL commands to reset auto-increment sequences to ensure they're at the correct values
+- This handles cases where existing records might have manually assigned IDs
+
+## Migration Instructions
+
+### To Apply the Changes:
+
+1. **Apply the database migration:**
+   ```bash
+   dotnet ef database update
+   ```
+
+2. **If you have an existing database with data:**
+   The migration includes sequence reset commands that will automatically adjust the auto-increment sequences to start from the correct value based on existing data.
+
+3. **Verify the changes:**
+   - Test creating new records via the API
+   - Confirm that IDs are automatically generated
+   - Ensure frontend cannot override ID values
+
+### Expected Behavior After Fix:
+
+- ✅ All new records will have automatically generated IDs
+- ✅ Frontend cannot specify ID values when creating records
+- ✅ Existing records are unaffected
+- ✅ Auto-increment sequences start from the correct values
+- ✅ Database integrity is maintained
+
+### Tables Affected:
+- `buildings`
+- `floors` 
+- `beacons`
+- `beacon_types`
+- `poi`
+- `poi_categories`
+- `route_nodes`
+
+## Testing
+
+Test each POST endpoint to ensure:
+1. New records are created successfully
+2. IDs are automatically assigned by the database
+3. Returned objects have valid auto-generated IDs
+4. Frontend cannot override the ID generation
+
+### Sample Test Commands:
+
+```bash
+# Test Building creation (should ignore any ID in request)
+curl -X POST "http://localhost:5000/api/Building" \
+  -H "Content-Type: application/json" \
+  -d '{"id": 999, "name": "Test Building", "description": "This ID should be ignored"}'
+
+# Test Floor creation
+curl -X POST "http://localhost:5000/api/Floor" \
+  -H "Content-Type: application/json" \
+  -d '{"id": 999, "name": "Test Floor", "floorNumber": 1, "buildingId": 1}'
+
+# Test Beacon creation (GeoJSON format)
+curl -X POST "http://localhost:5000/api/Beacon" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "type": "Feature",
+    "geometry": {"type": "Point", "coordinates": [-122.4194, 37.7749]},
+    "properties": {"id": 999, "name": "Test Beacon", "floorId": 1}
+  }'
+```
+
+In all cases, the returned object should have an auto-generated ID, not the ID specified in the request.

--- a/Migrations/20250921175423_FixAutoIncrementSequences.Designer.cs
+++ b/Migrations/20250921175423_FixAutoIncrementSequences.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NetTopologySuite.Geometries;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -13,9 +14,11 @@ using ai_indoor_nav_api.Data;
 namespace ai_indoor_nav_api.Migrations
 {
     [DbContext(typeof(MyDbContext))]
-    partial class MyDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250921175423_FixAutoIncrementSequences")]
+    partial class FixAutoIncrementSequences
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Migrations/20250921175423_FixAutoIncrementSequences.cs
+++ b/Migrations/20250921175423_FixAutoIncrementSequences.cs
@@ -1,0 +1,506 @@
+using System;
+using System.Collections.Generic;
+using Microsoft.EntityFrameworkCore.Migrations;
+using NetTopologySuite.Geometries;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace ai_indoor_nav_api.Migrations
+{
+    /// <inheritdoc />
+    public partial class FixAutoIncrementSequences : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterDatabase()
+                .Annotation("Npgsql:PostgresExtension:postgis", ",,");
+
+            migrationBuilder.CreateTable(
+                name: "AspNetRoles",
+                columns: table => new
+                {
+                    Id = table.Column<string>(type: "text", nullable: false),
+                    Name = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: true),
+                    NormalizedName = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: true),
+                    ConcurrencyStamp = table.Column<string>(type: "text", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_AspNetRoles", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "AspNetUsers",
+                columns: table => new
+                {
+                    Id = table.Column<string>(type: "text", nullable: false),
+                    UserName = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: true),
+                    NormalizedUserName = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: true),
+                    Email = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: true),
+                    NormalizedEmail = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: true),
+                    EmailConfirmed = table.Column<bool>(type: "boolean", nullable: false),
+                    PasswordHash = table.Column<string>(type: "text", nullable: true),
+                    SecurityStamp = table.Column<string>(type: "text", nullable: true),
+                    ConcurrencyStamp = table.Column<string>(type: "text", nullable: true),
+                    PhoneNumber = table.Column<string>(type: "text", nullable: true),
+                    PhoneNumberConfirmed = table.Column<bool>(type: "boolean", nullable: false),
+                    TwoFactorEnabled = table.Column<bool>(type: "boolean", nullable: false),
+                    LockoutEnd = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
+                    LockoutEnabled = table.Column<bool>(type: "boolean", nullable: false),
+                    AccessFailedCount = table.Column<int>(type: "integer", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_AspNetUsers", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "beacon_types",
+                columns: table => new
+                {
+                    id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    name = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: false),
+                    description = table.Column<string>(type: "text", nullable: true),
+                    transmission_power = table.Column<int>(type: "integer", nullable: true),
+                    battery_life = table.Column<int>(type: "integer", nullable: true),
+                    range_meters = table.Column<decimal>(type: "numeric(6,2)", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_beacon_types", x => x.id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "buildings",
+                columns: table => new
+                {
+                    id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    name = table.Column<string>(type: "character varying(255)", maxLength: 255, nullable: false),
+                    description = table.Column<string>(type: "text", nullable: true),
+                    created_at = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    updated_at = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_buildings", x => x.id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "poi_categories",
+                columns: table => new
+                {
+                    id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    name = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: false),
+                    color = table.Column<string>(type: "character varying(7)", maxLength: 7, nullable: false),
+                    description = table.Column<string>(type: "text", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_poi_categories", x => x.id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "AspNetRoleClaims",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    RoleId = table.Column<string>(type: "text", nullable: false),
+                    ClaimType = table.Column<string>(type: "text", nullable: true),
+                    ClaimValue = table.Column<string>(type: "text", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_AspNetRoleClaims", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_AspNetRoleClaims_AspNetRoles_RoleId",
+                        column: x => x.RoleId,
+                        principalTable: "AspNetRoles",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "AspNetUserClaims",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    UserId = table.Column<string>(type: "text", nullable: false),
+                    ClaimType = table.Column<string>(type: "text", nullable: true),
+                    ClaimValue = table.Column<string>(type: "text", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_AspNetUserClaims", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_AspNetUserClaims_AspNetUsers_UserId",
+                        column: x => x.UserId,
+                        principalTable: "AspNetUsers",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "AspNetUserLogins",
+                columns: table => new
+                {
+                    LoginProvider = table.Column<string>(type: "text", nullable: false),
+                    ProviderKey = table.Column<string>(type: "text", nullable: false),
+                    ProviderDisplayName = table.Column<string>(type: "text", nullable: true),
+                    UserId = table.Column<string>(type: "text", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_AspNetUserLogins", x => new { x.LoginProvider, x.ProviderKey });
+                    table.ForeignKey(
+                        name: "FK_AspNetUserLogins_AspNetUsers_UserId",
+                        column: x => x.UserId,
+                        principalTable: "AspNetUsers",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "AspNetUserRoles",
+                columns: table => new
+                {
+                    UserId = table.Column<string>(type: "text", nullable: false),
+                    RoleId = table.Column<string>(type: "text", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_AspNetUserRoles", x => new { x.UserId, x.RoleId });
+                    table.ForeignKey(
+                        name: "FK_AspNetUserRoles_AspNetRoles_RoleId",
+                        column: x => x.RoleId,
+                        principalTable: "AspNetRoles",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_AspNetUserRoles_AspNetUsers_UserId",
+                        column: x => x.UserId,
+                        principalTable: "AspNetUsers",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "AspNetUserTokens",
+                columns: table => new
+                {
+                    UserId = table.Column<string>(type: "text", nullable: false),
+                    LoginProvider = table.Column<string>(type: "text", nullable: false),
+                    Name = table.Column<string>(type: "text", nullable: false),
+                    Value = table.Column<string>(type: "text", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_AspNetUserTokens", x => new { x.UserId, x.LoginProvider, x.Name });
+                    table.ForeignKey(
+                        name: "FK_AspNetUserTokens_AspNetUsers_UserId",
+                        column: x => x.UserId,
+                        principalTable: "AspNetUsers",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "floors",
+                columns: table => new
+                {
+                    id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    name = table.Column<string>(type: "character varying(255)", maxLength: 255, nullable: false),
+                    floor_number = table.Column<int>(type: "integer", nullable: false),
+                    building_id = table.Column<int>(type: "integer", nullable: false),
+                    created_at = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    updated_at = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_floors", x => x.id);
+                    table.ForeignKey(
+                        name: "FK_floors_buildings_building_id",
+                        column: x => x.building_id,
+                        principalTable: "buildings",
+                        principalColumn: "id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "beacons",
+                columns: table => new
+                {
+                    id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    floor_id = table.Column<int>(type: "integer", nullable: false),
+                    beacon_type_id = table.Column<int>(type: "integer", nullable: true),
+                    name = table.Column<string>(type: "character varying(255)", maxLength: 255, nullable: false),
+                    uuid = table.Column<string>(type: "character varying(36)", maxLength: 36, nullable: true),
+                    major_id = table.Column<int>(type: "integer", nullable: true),
+                    minor_id = table.Column<int>(type: "integer", nullable: true),
+                    geometry = table.Column<Point>(type: "geometry (Point)", nullable: true),
+                    is_active = table.Column<bool>(type: "boolean", nullable: false),
+                    is_visible = table.Column<bool>(type: "boolean", nullable: false),
+                    battery_level = table.Column<int>(type: "integer", nullable: false),
+                    last_seen = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    installation_date = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    created_at = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    updated_at = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_beacons", x => x.id);
+                    table.ForeignKey(
+                        name: "FK_beacons_beacon_types_beacon_type_id",
+                        column: x => x.beacon_type_id,
+                        principalTable: "beacon_types",
+                        principalColumn: "id");
+                    table.ForeignKey(
+                        name: "FK_beacons_floors_floor_id",
+                        column: x => x.floor_id,
+                        principalTable: "floors",
+                        principalColumn: "id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "route_nodes",
+                columns: table => new
+                {
+                    id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    floor_id = table.Column<int>(type: "integer", nullable: false),
+                    connected_node_ids = table.Column<List<int>>(type: "integer[]", nullable: false),
+                    geometry = table.Column<Point>(type: "geometry", nullable: false),
+                    is_visible = table.Column<bool>(type: "boolean", nullable: false),
+                    created_at = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    updated_at = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_route_nodes", x => x.id);
+                    table.ForeignKey(
+                        name: "FK_route_nodes_floors_floor_id",
+                        column: x => x.floor_id,
+                        principalTable: "floors",
+                        principalColumn: "id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "poi",
+                columns: table => new
+                {
+                    id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    floor_id = table.Column<int>(type: "integer", nullable: false),
+                    category_id = table.Column<int>(type: "integer", nullable: true),
+                    name = table.Column<string>(type: "character varying(255)", maxLength: 255, nullable: false),
+                    description = table.Column<string>(type: "character varying(255)", maxLength: 255, nullable: true),
+                    poi_type = table.Column<string>(type: "text", nullable: false),
+                    color = table.Column<string>(type: "character varying(7)", maxLength: 7, nullable: false),
+                    is_visible = table.Column<bool>(type: "boolean", nullable: false),
+                    created_at = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    updated_at = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    geometry = table.Column<Polygon>(type: "geometry", nullable: true),
+                    closest_node_id = table.Column<int>(type: "integer", nullable: true),
+                    closest_node_distance = table.Column<double>(type: "double precision", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_poi", x => x.id);
+                    table.ForeignKey(
+                        name: "FK_poi_floors_floor_id",
+                        column: x => x.floor_id,
+                        principalTable: "floors",
+                        principalColumn: "id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_poi_poi_categories_category_id",
+                        column: x => x.category_id,
+                        principalTable: "poi_categories",
+                        principalColumn: "id");
+                    table.ForeignKey(
+                        name: "FK_poi_route_nodes_closest_node_id",
+                        column: x => x.closest_node_id,
+                        principalTable: "route_nodes",
+                        principalColumn: "id");
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_AspNetRoleClaims_RoleId",
+                table: "AspNetRoleClaims",
+                column: "RoleId");
+
+            migrationBuilder.CreateIndex(
+                name: "RoleNameIndex",
+                table: "AspNetRoles",
+                column: "NormalizedName",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_AspNetUserClaims_UserId",
+                table: "AspNetUserClaims",
+                column: "UserId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_AspNetUserLogins_UserId",
+                table: "AspNetUserLogins",
+                column: "UserId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_AspNetUserRoles_RoleId",
+                table: "AspNetUserRoles",
+                column: "RoleId");
+
+            migrationBuilder.CreateIndex(
+                name: "EmailIndex",
+                table: "AspNetUsers",
+                column: "NormalizedEmail");
+
+            migrationBuilder.CreateIndex(
+                name: "UserNameIndex",
+                table: "AspNetUsers",
+                column: "NormalizedUserName",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_beacon_types_name",
+                table: "beacon_types",
+                column: "name",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "idx_beacon_identifiers",
+                table: "beacons",
+                columns: new[] { "uuid", "major_id", "minor_id" },
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_beacons_beacon_type_id",
+                table: "beacons",
+                column: "beacon_type_id");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_beacons_floor_id",
+                table: "beacons",
+                column: "floor_id");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_floors_building_id_floor_number",
+                table: "floors",
+                columns: new[] { "building_id", "floor_number" },
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "idx_floor_category",
+                table: "poi",
+                columns: new[] { "floor_id", "category_id" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_poi_category_id",
+                table: "poi",
+                column: "category_id");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_poi_closest_node_id",
+                table: "poi",
+                column: "closest_node_id");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_poi_categories_name",
+                table: "poi_categories",
+                column: "name",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_route_nodes_floor_id",
+                table: "route_nodes",
+                column: "floor_id");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_route_nodes_geometry",
+                table: "route_nodes",
+                column: "geometry")
+                .Annotation("Npgsql:IndexMethod", "GIST");
+
+            // Reset sequences to ensure auto-increment works correctly
+            // This is important if there are existing records with manually assigned IDs
+            migrationBuilder.Sql(@"
+                -- Reset sequence for buildings table
+                SELECT setval(pg_get_serial_sequence('buildings', 'id'), COALESCE(MAX(id), 1), MAX(id) IS NOT NULL) FROM buildings;
+                
+                -- Reset sequence for floors table  
+                SELECT setval(pg_get_serial_sequence('floors', 'id'), COALESCE(MAX(id), 1), MAX(id) IS NOT NULL) FROM floors;
+                
+                -- Reset sequence for beacons table
+                SELECT setval(pg_get_serial_sequence('beacons', 'id'), COALESCE(MAX(id), 1), MAX(id) IS NOT NULL) FROM beacons;
+                
+                -- Reset sequence for beacon_types table
+                SELECT setval(pg_get_serial_sequence('beacon_types', 'id'), COALESCE(MAX(id), 1), MAX(id) IS NOT NULL) FROM beacon_types;
+                
+                -- Reset sequence for poi table
+                SELECT setval(pg_get_serial_sequence('poi', 'id'), COALESCE(MAX(id), 1), MAX(id) IS NOT NULL) FROM poi;
+                
+                -- Reset sequence for poi_categories table
+                SELECT setval(pg_get_serial_sequence('poi_categories', 'id'), COALESCE(MAX(id), 1), MAX(id) IS NOT NULL) FROM poi_categories;
+                
+                -- Reset sequence for route_nodes table
+                SELECT setval(pg_get_serial_sequence('route_nodes', 'id'), COALESCE(MAX(id), 1), MAX(id) IS NOT NULL) FROM route_nodes;
+            ");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "AspNetRoleClaims");
+
+            migrationBuilder.DropTable(
+                name: "AspNetUserClaims");
+
+            migrationBuilder.DropTable(
+                name: "AspNetUserLogins");
+
+            migrationBuilder.DropTable(
+                name: "AspNetUserRoles");
+
+            migrationBuilder.DropTable(
+                name: "AspNetUserTokens");
+
+            migrationBuilder.DropTable(
+                name: "beacons");
+
+            migrationBuilder.DropTable(
+                name: "poi");
+
+            migrationBuilder.DropTable(
+                name: "AspNetRoles");
+
+            migrationBuilder.DropTable(
+                name: "AspNetUsers");
+
+            migrationBuilder.DropTable(
+                name: "beacon_types");
+
+            migrationBuilder.DropTable(
+                name: "poi_categories");
+
+            migrationBuilder.DropTable(
+                name: "route_nodes");
+
+            migrationBuilder.DropTable(
+                name: "floors");
+
+            migrationBuilder.DropTable(
+                name: "buildings");
+        }
+    }
+}

--- a/Models/Beacon.cs
+++ b/Models/Beacon.cs
@@ -14,7 +14,7 @@ namespace ai_indoor_nav_api.Models
     {
         [Key]
         [Column("id")]
-        public int Id { get; set; }
+        public int Id { get; init; }
 
         [Required]
         [StringLength(100)]
@@ -40,7 +40,7 @@ namespace ai_indoor_nav_api.Models
     [Table("beacons")]
     public class Beacon
     {
-        [Key] [Column("id")] public int Id { get; set; }
+        [Key] [Column("id")] public int Id { get; init; }
 
         [Required] [Column("floor_id")] public int FloorId { get; set; }
 

--- a/Models/Building.cs
+++ b/Models/Building.cs
@@ -1,4 +1,4 @@
-﻿using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
 using Newtonsoft.Json;
 
@@ -9,7 +9,7 @@ namespace ai_indoor_nav_api.Models
     {
         [Key]
         [Column("id")]
-        public int Id { get; set; }
+        public int Id { get; init; }
 
         [Required]
         [StringLength(255)]

--- a/Models/Floor.cs
+++ b/Models/Floor.cs
@@ -1,4 +1,4 @@
-﻿using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
 using Newtonsoft.Json;
 using Microsoft.EntityFrameworkCore;
@@ -11,7 +11,7 @@ namespace ai_indoor_nav_api.Models
     {
         [Key]
         [Column("id")]
-        public int Id { get; set; }
+        public int Id { get; init; }
 
         [Required]
         [StringLength(255)]

--- a/Models/Node.cs
+++ b/Models/Node.cs
@@ -11,7 +11,7 @@ namespace ai_indoor_nav_api.Models
     {
         [Key]
         [Column("id")]
-        public int Id { get; set; }
+        public int Id { get; init; }
 
         [Required]
         [Column("floor_id")]

--- a/Util/GeoJsonExtensions.cs
+++ b/Util/GeoJsonExtensions.cs
@@ -116,6 +116,9 @@ public static class GeoJsonExtensions
                 p.CanWrite);
 
             if (property == null) continue;
+            
+            // Skip ID property - let database generate it
+            if (string.Equals(property.Name, "Id", StringComparison.OrdinalIgnoreCase)) continue;
 
             try
             {
@@ -243,6 +246,9 @@ public static class GeoJsonExtensions
                     string.Equals(NormalizeName(p.Name), NormalizeName(key), StringComparison.OrdinalIgnoreCase));
 
             if (prop == null || !prop.CanWrite) continue;
+            
+            // Skip ID property - let database generate it
+            if (string.Equals(prop.Name, "Id", StringComparison.OrdinalIgnoreCase)) continue;
 
             try
             {


### PR DESCRIPTION
Enforce backend auto-generation of IDs for all objects and prevent frontend assignment to improve data integrity.

The previous implementation allowed the frontend to provide ID values for new objects, which is a security and data integrity risk. This PR ensures that IDs are always generated by the backend database. The fix addresses model property setters, controller POST endpoint logic, and GeoJSON deserialization, along with a migration to reset database sequences.

---
<a href="https://cursor.com/background-agent?bcId=bc-fe43ffec-4731-4d2e-a053-8fd3d62dc79e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-fe43ffec-4731-4d2e-a053-8fd3d62dc79e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

